### PR TITLE
Update deps

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.2.12",
-    "@powerhousedao/analytics-engine-core": "0.3.0",
+    "@powerhousedao/analytics-engine-core": "0.3.2",
     "@powerhousedao/analytics-engine-knex": "0.4.0",
     "date-fns": "^3.6.0",
     "events": "^3.3.0",

--- a/browser/src/MemoryAnalyticsStore.ts
+++ b/browser/src/MemoryAnalyticsStore.ts
@@ -7,7 +7,6 @@ import {
   SqlQueryLogger,
   SqlResultsLogger,
 } from "@powerhousedao/analytics-engine-knex";
-import fs from "fs";
 import knexFactory, { Knex } from "knex";
 import { parseRawResults, PGLiteQueryExecutor } from "./PgLiteExecutor.js";
 import { PGlite } from "@electric-sql/pglite";

--- a/compat/package.json
+++ b/compat/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@powerhousedao/analytics-engine-browser": "0.4.0",
-    "@powerhousedao/analytics-engine-core": "0.3.0",
+    "@powerhousedao/analytics-engine-core": "0.3.2",
     "@powerhousedao/analytics-engine-knex": "0.4.0",
     "@powerhousedao/analytics-engine-pg": "0.4.0",
     "knex": "^3.1.0",

--- a/knex/package.json
+++ b/knex/package.json
@@ -17,7 +17,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@powerhousedao/analytics-engine-core": "0.3.0",
+    "@powerhousedao/analytics-engine-core": "0.3.2",
     "@types/luxon": "^3.4.2",
     "@types/node": "^22.4.2",
     "@types/pg": "^8.11.6",

--- a/pg/package.json
+++ b/pg/package.json
@@ -17,7 +17,7 @@
     "test": "PG_CONNECTION_STRING=postgresql://postgres:password@localhost:5555/analytics vitest"
   },
   "dependencies": {
-    "@powerhousedao/analytics-engine-core": "0.3.0",
+    "@powerhousedao/analytics-engine-core": "0.3.2",
     "@powerhousedao/analytics-engine-knex": "0.4.0",
     "date-fns": "^3.6.0",
     "knex": "^3.1.0",


### PR DESCRIPTION
The latest version of the `core` package is at 0.3.2. Since the packages have its version set as 0.3.0 there is a type issue due to the version mismatch.
I think we'll also need to update the `knex` version, when it is released, on the `browser` and `pg` packages.